### PR TITLE
fix(infra): strip dots from CloudFront response headers policy name

### DIFF
--- a/infra/states/pablofallas.name/main.tf
+++ b/infra/states/pablofallas.name/main.tf
@@ -112,7 +112,8 @@ data "aws_cloudfront_cache_policy" "caching_optimized" {
 # CLOUDFRONT RESPONSE HEADERS POLICY - security headers
 ##############################################################################
 resource "aws_cloudfront_response_headers_policy" "security_headers" {
-  name = "${var.service_name}-security-headers"
+  # CloudFront policy names only allow alphanumerics, dashes, underscores.
+  name = "${replace(var.service_name, ".", "-")}-security-headers"
 
   security_headers_config {
     content_type_options {


### PR DESCRIPTION
## Summary

The first deploy after the Astro migration failed at the Terraform apply step because the new `aws_cloudfront_response_headers_policy.security_headers` resource was named `pablofallas.name-security-headers`. CloudFront only allows alphanumerics, dashes, and underscores in policy names, so the API returned `InvalidArgument: The parameter ... contains characters other than alphanumericals, dashes, and underscores.` This fix substitutes any `.` in `var.service_name` for `-` before composing the policy name.