### PR TITLE
ci: bump actions to Node 24-compatible versions + Dependabot CI guard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,18 +19,22 @@ jobs:
     steps:
       # Step 1: Checkout Repository
       - name: Checkout Repository
-        uses: actions/checkout@v4
-    
+        uses: actions/checkout@v6
+
       # Step 2: Set up Node.js
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-   
+
       # Step 3: Configure AWS credentials with OIDC
+      # Dependabot PRs cannot access repo secrets — only run AWS auth for
+      # everyone else. The push branch deploys; non-Dependabot PRs still get
+      # plan + state-backed terraform validate.
       - name: Configure AWS credentials with OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+        if: github.actor != 'dependabot[bot]'
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -49,28 +53,30 @@ jobs:
 
       # Step 7: Set up Terraform
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ~1.9
 
-      # Step 8: Terraform Format Check
+      # Step 8: Terraform Format Check (no AWS needed)
       - name: Terraform Format Check
         working-directory: infra/states/pablofallas.name
         run: terraform fmt -check -diff
 
-      # Step 9: Terraform Init
+      # Step 9: Terraform Init (needs S3 backend access — skip for Dependabot)
       - name: Terraform Init
+        if: github.actor != 'dependabot[bot]'
         working-directory: infra/states/pablofallas.name
         run: terraform init
 
-      # Step 10: Terraform Validate
+      # Step 10: Terraform Validate (depends on Init)
       - name: Terraform Validate
+        if: github.actor != 'dependabot[bot]'
         working-directory: infra/states/pablofallas.name
         run: terraform validate
 
-      # Step 11: Terraform Plan (Only on Pull Requests)
+      # Step 11: Terraform Plan (Only on Pull Requests, not Dependabot)
       - name: Terraform Plan
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         working-directory: infra/states/pablofallas.name
         run: terraform plan
 


### PR DESCRIPTION
## Summary

Bumps the three GitHub Actions that the runner has been warning are pinned to Node 20: `actions/checkout` from 4 to 6, `aws-actions/configure-aws-credentials` from 4 to 6, and `hashicorp/setup-terraform` from 3 to 4. From June 2026 the runner forces those Node 20 actions onto Node 24, and from September 2026 Node 20 is removed entirely — moving to the latest action majors gets us onto a supported runtime now. The new majors are behaviourally compatible for our usage (we don't rely on any v4/v5 quirks); the existing workflow steps work unchanged.

Also adds a small guard to the workflow so Dependabot PRs aren't broken by the AWS OIDC step. Dependabot PRs do not inherit Actions secrets (GitHub split Dependabot secrets from Actions secrets in 2021), so any step that reads `${{ secrets.AWS_ROLE_ARN }}` fails on Dependabot-authored PRs with `Credentials could not be loaded`. The fix is `if: github.actor != 'dependabot[bot]'` on the AWS-coupled steps (OIDC configure, `terraform init`, `terraform validate`, `terraform plan`). Dependabot PRs still run install, type-check, build and `terraform fmt -check` — enough to catch the changes from typical Dependabot PRs without needing AWS access. The push-to-main deploy flow is unchanged.

This supersedes #8, #9 and #10 (the matching individual Dependabot bumps that landed CI-broken for the same secrets reason). I'll close those once this merges.