### PR TITLE
feat: add Umami analytics + open CSP for cloud.umami.is

### DIFF
--- a/infra/states/pablofallas.name/main.tf
+++ b/infra/states/pablofallas.name/main.tf
@@ -141,11 +141,11 @@ resource "aws_cloudfront_response_headers_policy" "security_headers" {
     content_security_policy {
       content_security_policy = join("; ", [
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'unsafe-inline' https://cloud.umami.is",
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
         "img-src 'self' data: https:",
         "font-src 'self' data: https://fonts.gstatic.com",
-        "connect-src 'self'",
+        "connect-src 'self' https://cloud.umami.is",
         "manifest-src 'self'",
         "worker-src 'self'",
         "frame-ancestors 'none'",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -104,6 +104,17 @@ const personJsonLd = {
 
     <script type="application/ld+json" set:html={JSON.stringify(personJsonLd)} is:inline />
 
+    {
+      import.meta.env.PROD && (
+        <script
+          is:inline
+          defer
+          src="https://cloud.umami.is/script.js"
+          data-website-id="6a05ffa5-cebc-46b0-b971-d5367e752805"
+        />
+      )
+    }
+
     {pwaInfo && <Fragment set:html={pwaInfo.webManifest.linkTag} />}
   </head>
   <body>


### PR DESCRIPTION
## Summary

Adds the Umami Cloud analytics script to `Base.astro`, gated on `import.meta.env.PROD` so `astro dev` runs don't show up in the dashboard. The script is loaded with `defer` so it doesn't block first paint, and Umami is cookie-free / GDPR-friendly by design so we don't need a consent banner. The `data-website-id` is the public ID from the user's Umami project and isn't sensitive (it's visible in every page's source on every Umami-tracked site, so hard-coding it inline is fine).

The CloudFront response headers policy CSP in `infra/states/pablofallas.name/main.tf` is widened to allow `https://cloud.umami.is`. Specifically, `script-src` now includes it (for the `/script.js` load) and `connect-src` now includes it (for the `/api/send` POSTs Umami's script makes when reporting pageviews). Without those, the existing `default-src 'self'` baseline would silently block both.

## Test plan

- [ ] CI passes and the terraform plan only shows the CSP change on `aws_cloudfront_response_headers_policy.security_headers`
- [ ] After deploy, load the live site in an incognito window with DevTools open: confirm `cloud.umami.is/script.js` loads with 200 (not blocked by CSP) and that there's an outgoing POST to `cloud.umami.is/api/send` containing the pageview
- [ ] Confirm a pageview appears in the Umami dashboard
- [ ] Local `npm run dev` should NOT load the script (gated on `import.meta.env.PROD`) — verify by checking that `cloud.umami.is` does not appear in the Network tab during local dev