### PR TITLE
chore: disable deploy workflow + document site is offline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,103 +1,133 @@
-name: CI/CD
+# =============================================================================
+# THIS WORKFLOW IS INTENTIONALLY DISABLED.
+#
+# The live site is currently offline (`terraform destroy` was run) for privacy
+# reasons related to the German Impressumspflicht — see README.md for context.
+# The original push/PR triggers and deploy steps are preserved below as
+# commented lines so this can be restored verbatim by un-commenting them.
+#
+# To re-enable:
+#   1. Provision a valid Impressum address in src/pages/impressum.astro
+#      and src/pages/datenschutz.astro.
+#   2. Replace this stub with the commented content below
+#      (a block-uncomment in your editor will do).
+# =============================================================================
+name: CI/CD (disabled)
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-env:
-  NODE_VERSION: '22'
-  AWS_REGION: us-east-1
+  workflow_dispatch: # manual-only; never fires on push or PR
 
 jobs:
-  build-and-deploy:
+  noop:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     steps:
-      # Step 1: Checkout Repository
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      # Step 2: Set up Node.js
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      # Step 3: Configure AWS credentials with OIDC
-      # Dependabot PRs cannot access repo secrets — only run AWS auth for
-      # everyone else. The push branch deploys; non-Dependabot PRs still get
-      # plan + state-backed terraform validate.
-      - name: Configure AWS credentials with OIDC
-        if: github.actor != 'dependabot[bot]'
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      # Step 4: Install Dependencies
-      - name: Install Dependencies
-        run: npm ci
-
-      # Step 5: Type-check (Astro + TypeScript)
-      - name: Type-check
-        run: npm run type-check
-
-      # Step 6: Build Project
-      - name: Build Project
-        run: npm run build
-
-      # Step 7: Set up Terraform
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v4
-        with:
-          terraform_version: ~1.9
-
-      # Step 8: Terraform Format Check (no AWS needed)
-      - name: Terraform Format Check
-        working-directory: infra/states/pablofallas.name
-        run: terraform fmt -check -diff
-
-      # Step 9: Terraform Init (needs S3 backend access — skip for Dependabot)
-      - name: Terraform Init
-        if: github.actor != 'dependabot[bot]'
-        working-directory: infra/states/pablofallas.name
-        run: terraform init
-
-      # Step 10: Terraform Validate (depends on Init)
-      - name: Terraform Validate
-        if: github.actor != 'dependabot[bot]'
-        working-directory: infra/states/pablofallas.name
-        run: terraform validate
-
-      # Step 11: Terraform Plan (Only on Pull Requests, not Dependabot)
-      - name: Terraform Plan
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-        working-directory: infra/states/pablofallas.name
-        run: terraform plan
-
-      # Step 12: Terraform Apply (Only on Push to Main)
-      - name: Terraform Apply
-        if: github.event_name == 'push'
-        working-directory: infra/states/pablofallas.name
-        run: terraform apply -auto-approve
-
-      # Step 13: Sync to S3 (Only on Push to Main)
-      - name: Sync to S3
-        if: github.event_name == 'push'
+      - name: Workflow intentionally disabled
         run: |
-          aws s3 sync dist/ s3://pablofallas.name --delete
+          echo "The deploy pipeline is intentionally disabled."
+          echo "See README.md and the comment block at the top of this file."
 
-      # Step 14: Invalidate CloudFront cache (Only on Push to Main)
-      - name: Invalidate CloudFront cache
-        if: github.event_name == 'push'
-        working-directory: infra/states/pablofallas.name
-        run: |
-          DIST_ID=$(terraform output -raw cloudfront_distribution_id)
-          aws cloudfront create-invalidation \
-            --distribution-id "$DIST_ID" \
-            --paths "/*"
+# -----------------------------------------------------------------------------
+# Original workflow preserved below — uncomment to restore.
+# -----------------------------------------------------------------------------
+#
+# on:
+#   push:
+#     branches: [main]
+#   pull_request:
+#     branches: [main]
+#
+# env:
+#   NODE_VERSION: '22'
+#   AWS_REGION: us-east-1
+#
+# jobs:
+#   build-and-deploy:
+#     runs-on: ubuntu-latest
+#     permissions:
+#       id-token: write
+#       contents: read
+#     steps:
+#       # Step 1: Checkout Repository
+#       - name: Checkout Repository
+#         uses: actions/checkout@v6
+#
+#       # Step 2: Set up Node.js
+#       - name: Set up Node.js
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: ${{ env.NODE_VERSION }}
+#           cache: 'npm'
+#
+#       # Step 3: Configure AWS credentials with OIDC
+#       # Dependabot PRs cannot access repo secrets — only run AWS auth for
+#       # everyone else. The push branch deploys; non-Dependabot PRs still get
+#       # plan + state-backed terraform validate.
+#       - name: Configure AWS credentials with OIDC
+#         if: github.actor != 'dependabot[bot]'
+#         uses: aws-actions/configure-aws-credentials@v6
+#         with:
+#           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+#           aws-region: ${{ env.AWS_REGION }}
+#
+#       # Step 4: Install Dependencies
+#       - name: Install Dependencies
+#         run: npm ci
+#
+#       # Step 5: Type-check (Astro + TypeScript)
+#       - name: Type-check
+#         run: npm run type-check
+#
+#       # Step 6: Build Project
+#       - name: Build Project
+#         run: npm run build
+#
+#       # Step 7: Set up Terraform
+#       - name: Set up Terraform
+#         uses: hashicorp/setup-terraform@v4
+#         with:
+#           terraform_version: ~1.9
+#
+#       # Step 8: Terraform Format Check (no AWS needed)
+#       - name: Terraform Format Check
+#         working-directory: infra/states/pablofallas.name
+#         run: terraform fmt -check -diff
+#
+#       # Step 9: Terraform Init (needs S3 backend access — skip for Dependabot)
+#       - name: Terraform Init
+#         if: github.actor != 'dependabot[bot]'
+#         working-directory: infra/states/pablofallas.name
+#         run: terraform init
+#
+#       # Step 10: Terraform Validate (depends on Init)
+#       - name: Terraform Validate
+#         if: github.actor != 'dependabot[bot]'
+#         working-directory: infra/states/pablofallas.name
+#         run: terraform validate
+#
+#       # Step 11: Terraform Plan (Only on Pull Requests, not Dependabot)
+#       - name: Terraform Plan
+#         if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+#         working-directory: infra/states/pablofallas.name
+#         run: terraform plan
+#
+#       # Step 12: Terraform Apply (Only on Push to Main)
+#       - name: Terraform Apply
+#         if: github.event_name == 'push'
+#         working-directory: infra/states/pablofallas.name
+#         run: terraform apply -auto-approve
+#
+#       # Step 13: Sync to S3 (Only on Push to Main)
+#       - name: Sync to S3
+#         if: github.event_name == 'push'
+#         run: |
+#           aws s3 sync dist/ s3://pablofallas.name --delete
+#
+#       # Step 14: Invalidate CloudFront cache (Only on Push to Main)
+#       - name: Invalidate CloudFront cache
+#         if: github.event_name == 'push'
+#         working-directory: infra/states/pablofallas.name
+#         run: |
+#           DIST_ID=$(terraform output -raw cloudfront_distribution_id)
+#           aws cloudfront create-invalidation \
+#             --distribution-id "$DIST_ID" \
+#             --paths "/*"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,37 @@
 Personal portfolio site at [pablofallas.name](https://pablofallas.name).
 Static, served from S3 + CloudFront, fully provisioned via Terraform.
 
+## Status: not currently deployed
+
+As of May 2026 the live site is **intentionally offline**. The AWS
+infrastructure has been torn down via `terraform destroy` and the GitHub
+Actions deploy workflow is commented out so pushes to `main` don't recreate
+it.
+
+The reason is the German Impressumspflicht (§5 DDG): any career-style
+portfolio operated from Germany legally requires a verifiable street
+address on a publicly-reachable Impressum page. Publishing my home address
+on a publicly indexed page is a privacy trade-off I'd rather not make
+right now, and at the moment I'm not actively job-hunting so the
+cost / benefit of keeping the site live doesn't work out.
+
+The codebase, terraform stack, design system and content here are
+preserved as-is so the site can be re-deployed at any time without
+re-engineering anything. To bring it back online:
+
+1. Provision a valid Impressum address (a P.O. Box, `c/o` arrangement, or
+   a virtual mailbox such as Hauspost works) and update the placeholder
+   in [`src/pages/impressum.astro`](src/pages/impressum.astro) and
+   [`src/pages/datenschutz.astro`](src/pages/datenschutz.astro).
+2. Restore the deploy workflow by uncommenting the block at the bottom
+   of [`.github/workflows/main.yml`](.github/workflows/main.yml).
+3. Push to `main`. The first push will recreate the S3 bucket, CloudFront
+   distribution, ACM cert and Route53 records via `terraform apply`, then
+   sync the build artefacts.
+
+The domain registration itself (in the Route53 hosted zone) is unaffected
+by the destroy and remains owned.
+
 ## Stack
 
 ### Frontend


### PR DESCRIPTION
## Summary

I ran `terraform destroy` on the website infrastructure (CloudFront distribution, S3 bucket, ACM certificate, Route53 records, response headers policy, OAC) because publishing a home address on a publicly-reachable Impressum is a permanent privacy trade-off I don't want to make while I'm not actively job-hunting. The Route53 hosted zone is unaffected — the domain registration is preserved.

This PR makes the repo reflect that:

`.github/workflows/main.yml` is reduced to a no-op stub that only fires on `workflow_dispatch`. The previous push / PR triggers and all fourteen deploy steps are preserved as commented lines below the stub so the workflow can be restored verbatim by un-commenting them. Without this, the next push to `main` would silently rerun `terraform apply` and recreate everything from scratch.

`README.md` gains a "Status: not currently deployed" section right under the title explaining why the site is offline (Impressumspflicht under §5 DDG), what's preserved (codebase, terraform stack, design system, domain registration), and the three steps required to bring it back online (provision a valid Impressum address, uncomment the workflow block, push to `main`).